### PR TITLE
Improve IP logging

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -8,6 +8,9 @@ const nextConfig: NextConfig = {
   eslint: {
     ignoreDuringBuilds: true,
   },
+  experimental: {
+    trustHostHeader: true,
+  },
   images: {
     remotePatterns: [
       {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,8 +2,14 @@ import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 
 export function middleware(request: NextRequest) {
-  const { geo, ip } = request;
-  const userAgent = request.headers.get('user-agent');
+  const { geo } = request
+  const userAgent = request.headers.get('user-agent')
+
+  const ip =
+    request.ip ??
+    request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ??
+    request.headers.get('x-real-ip') ??
+    null
   
   const logData = {
     message: "User access",


### PR DESCRIPTION
## Summary
- expose `trustHostHeader` in Next.js config so the server can trust proxied IPs
- log remote user IPs by checking request.ip and proxy headers

## Testing
- `npm run lint` *(fails: 403 Forbidden)*
- `npm run typecheck` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687fbfc0136c8324a2108137018e65b1